### PR TITLE
カレンダーの新規登録機能の曜日選択機能実装

### DIFF
--- a/app/javascript/packs/habits_new.js
+++ b/app/javascript/packs/habits_new.js
@@ -1,19 +1,67 @@
 window.addEventListener('DOMContentLoaded', function(){
-  /** jQueryの処理 */
-  // $("#button1").click(function(){
-  //   const str1 = $("#hidden1").val();
-  //   $("#span1").text(str1);
-  // });
-  $("#dayOfWeek0").click(function(){
-    $(this).toggleClass("hid bg-gray-50 text-blue-700 bg-blue-600 text-slate-50");
-    console.log($(this).hasClass("hid"));
+  $(".dayOfWeek").click(function(){
+    let week_value = check_week_value($(this).val());
+
+    $(this).toggleClass("hid bg-gray-50 text-blue-700 bg-blue-700 text-slate-50");
+
     if ($(this).hasClass("hid")) {
-      $("#hidden2").val("0");
-      $("#span1").text($("#hidden2").val(""));
+      let current_value = $("#week_hidden").val();
+      // クリックしてclassが存在するとき
+      if (current_value != '')
+      {
+        // 値が設定されている場合(ex.0がhidden_fieldに設定済みの場合. [0] ⇨ [0,1] ⇨ 0,1)
+        let split_value = current_value.split(',');
+        split_value.push(week_value);
+        let new_value = split_value.join(',');
+        $("#week_hidden").val(new_value);
+      } else {
+        // 値が設定されていない場合
+        $("#week_hidden").val(week_value);
+      }
     } else {
-      $("#hidden2").val("");
-      $("#span1").text("");
+      let current_value = $("#week_hidden").val();
+      if (current_value != '')
+      // 値が存在する時
+      {
+        let split_value = current_value.split(',');
+        if (split_value.includes(week_value)) {
+          let index = split_value.indexOf(week_value);
+          split_value.splice(index, 1);
+          let new_value = split_value.join(',');
+          $("#week_hidden").val(new_value);
+        }
+      }
     };
   });
 
+  function check_week_value(checked_week_value) {
+    switch (checked_week_value) {
+      case "日":
+        week_value = '0';
+        break;
+      case "月":
+        week_value = '1';
+        break;
+      case "火":
+        week_value = '2';
+        break;
+      case "水":
+        week_value = '3';
+        break;
+      case "木":
+        week_value = '4';
+        break;
+      case "金":
+        week_value = '5';
+        break;
+      case "土":
+        week_value = '6';
+        break;
+      default:
+        week_value = '';
+        break;
+    }
+
+    return week_value;
+  }
 });

--- a/app/views/habits/new.html.erb
+++ b/app/views/habits/new.html.erb
@@ -85,18 +85,14 @@
             <label for="title" class="block mb-2 text-gray-600 dark:text-white font-bold">取り組む曜日<span class="text-red-500 ml-2 text-sm">* 必須</span></label>
             <div class="mt-2">
               <div class="justify-start my-2 select-none flex">
-                <%= f.hidden_field :day_of_week, value: "", id: "hidden2" %>
-                <p>色 <span id="span1"></span></p>
-                <input type="button" value="日" id="dayOfWeek0" class="bg-gray-50 bg-transparent text-blue-700 font-semibold py-2 px-4 border border-blue-500 rounded-full" />
-                <%# <input type="hidden" value="1" id="hidden1"> %>
-                <%# <input type="button" id="button1" value="sun" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full" /> %>
-                <%# <%= f.button "日", class: "py-2 px-4 shadow-md no-underline rounded-full bg-blue text-white font-sans font-semibold text-sm border-blue btn-primary hover:text-white hover:bg-blue-light focus:outline-none active:shadow-none mr-2"
-                <%# <%= f.button "月", class: "py-2 px-4 shadow-md no-underline rounded-full bg-blue text-white font-sans font-semibold text-sm border-blue btn-primary hover:text-white hover:bg-blue-light focus:outline-none active:shadow-none mr-2" %>
-                <%# <%= f.button "火", class: "py-2 px-4 shadow-md no-underline rounded-full bg-blue text-white font-sans font-semibold text-sm border-blue btn-primary hover:text-white hover:bg-blue-light focus:outline-none active:shadow-none mr-2" %>
-                <%# <%= f.button "水", class: "py-2 px-4 shadow-md no-underline rounded-full bg-blue text-white font-sans font-semibold text-sm border-blue btn-primary hover:text-white hover:bg-blue-light focus:outline-none active:shadow-none mr-2" %>
-                <%# <%= f.button "木", class: "py-2 px-4 shadow-md no-underline rounded-full bg-blue text-white font-sans font-semibold text-sm border-blue btn-primary hover:text-white hover:bg-blue-light focus:outline-none active:shadow-none mr-2" %>
-                <%# <%= f.button "金", class: "py-2 px-4 shadow-md no-underline rounded-full bg-blue text-white font-sans font-semibold text-sm border-blue btn-primary hover:text-white hover:bg-blue-light focus:outline-none active:shadow-none mr-2" %>
-                <%# <%= f.button "土", class: "py-2 px-4 shadow-md no-underline rounded-full bg-blue text-white font-sans font-semibold text-sm border-blue btn-primary hover:text-white hover:bg-blue-light focus:outline-none active:shadow-none mr-2" %>
+                <%= f.hidden_field :day_of_week, value: "", id: "week_hidden" %>
+                <input type="button" value="日" class="dayOfWeek bg-gray-50 bg-transparent text-blue-700 font-semibold py-2 px-4 border border-blue-500 rounded-full" />
+                <input type="button" value="月" class="dayOfWeek bg-gray-50 bg-transparent text-blue-700 font-semibold py-2 px-4 border border-blue-500 rounded-full" />
+                <input type="button" value="火" class="dayOfWeek bg-gray-50 bg-transparent text-blue-700 font-semibold py-2 px-4 border border-blue-500 rounded-full" />
+                <input type="button" value="水" class="dayOfWeek bg-gray-50 bg-transparent text-blue-700 font-semibold py-2 px-4 border border-blue-500 rounded-full" />
+                <input type="button" value="木" class="dayOfWeek bg-gray-50 bg-transparent text-blue-700 font-semibold py-2 px-4 border border-blue-500 rounded-full" />
+                <input type="button" value="金" class="dayOfWeek bg-gray-50 bg-transparent text-blue-700 font-semibold py-2 px-4 border border-blue-500 rounded-full" />
+                <input type="button" value="土" class="dayOfWeek bg-gray-50 bg-transparent text-blue-700 font-semibold py-2 px-4 border border-blue-500 rounded-full" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 概要
カレンダーの新規登録機能の曜日選択機能実装

## 内容
習慣の新規登録画面の曜日のクリックイベントを用いてf.hidden_fieldのvalue値に設定
[![Image from Gyazo](https://i.gyazo.com/18f3960bf402745a6d57a6739e9ed571.gif)](https://gyazo.com/18f3960bf402745a6d57a6739e9ed571)

- 日曜日から土曜日までそれぞれ0~6の数字をボタンのvalue値に割り当てて、ボタンを実装
- jQueryでボタンがクリックされた時だけ、そのvalue値を取得。
- jQueryで取得したvalue値を、f.hidden_fieldのvalue値に配列で取得

Resolves #21
